### PR TITLE
[PW-5175] - Add support for REFUND_FAILED notification

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -27,8 +27,11 @@ use Adyen\Webhook\Exception\InvalidDataException;
 
 class Notification
 {
+    const PROPERTY_EVENT_CODE = 'eventCode';
+    const PROPERTY_SUCCESS = 'success';
+
     const REQUIRED_DATA = [
-        'eventCode'
+        self::PROPERTY_EVENT_CODE
     ];
 
     public $eventCode;
@@ -42,9 +45,9 @@ class Notification
         self::validateNotificationData($notificationData);
 
         $notification = new self();
-        $notification->eventCode = $notificationData['eventCode'];
-        if (array_key_exists('success', $notificationData)) {
-            $notification->success = $notificationData['success'];
+        $notification->eventCode = $notificationData[self::PROPERTY_EVENT_CODE];
+        if (array_key_exists(self::PROPERTY_SUCCESS, $notificationData)) {
+            $notification->success = $notificationData[self::PROPERTY_SUCCESS];
         }
 
         return $notification;
@@ -67,11 +70,15 @@ class Notification
         $eventCodes = new \ReflectionClass(EventCodes::class);
 
         foreach (self::REQUIRED_DATA as $property) {
+            // If required data is missing
             if (!isset($data[$property])) {
                 $missing[] = $property;
             }
-            if (isset($data['eventCode']) && !in_array($data['eventCode'], $eventCodes->getConstants())) {
-                $invalid[] = 'eventCode';
+
+            // If an invalid event code is passed
+            if (isset($data[self::PROPERTY_EVENT_CODE]) &&
+                !in_array($data[self::PROPERTY_EVENT_CODE], $eventCodes->getConstants())) {
+                $invalid[] = self::PROPERTY_EVENT_CODE;
             }
         }
 

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -30,8 +30,9 @@ class Notification
     const PROPERTY_EVENT_CODE = 'eventCode';
     const PROPERTY_SUCCESS = 'success';
 
-    const REQUIRED_DATA = [
-        self::PROPERTY_EVENT_CODE
+    const REQUIRED_PROPERTIES = [
+        self::PROPERTY_EVENT_CODE,
+        self::PROPERTY_SUCCESS
     ];
 
     public $eventCode;
@@ -46,9 +47,7 @@ class Notification
 
         $notification = new self();
         $notification->eventCode = $notificationData[self::PROPERTY_EVENT_CODE];
-        if (array_key_exists(self::PROPERTY_SUCCESS, $notificationData)) {
-            $notification->success = $notificationData[self::PROPERTY_SUCCESS];
-        }
+        $notification->success = $notificationData[self::PROPERTY_SUCCESS];
 
         return $notification;
     }
@@ -69,7 +68,7 @@ class Notification
         $invalid = [];
         $eventCodes = new \ReflectionClass(EventCodes::class);
 
-        foreach (self::REQUIRED_DATA as $property) {
+        foreach (self::REQUIRED_PROPERTIES as $property) {
             // If required data is missing
             if (!isset($data[$property])) {
                 $missing[] = $property;

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -27,6 +27,10 @@ use Adyen\Webhook\Exception\InvalidDataException;
 
 class Notification
 {
+    const REQUIRED_DATA = [
+        'eventCode'
+    ];
+
     public $eventCode;
     public $success;
 
@@ -39,7 +43,9 @@ class Notification
 
         $notification = new self();
         $notification->eventCode = $notificationData['eventCode'];
-        $notification->success = $notificationData['success'];
+        if (array_key_exists('success', $notificationData)) {
+            $notification->success = $notificationData['success'];
+        }
 
         return $notification;
     }
@@ -56,13 +62,11 @@ class Notification
 
     private static function validateNotificationData(array $data)
     {
-        $class_vars = get_class_vars(self::class);
-
         $missing = [];
         $invalid = [];
         $eventCodes = new \ReflectionClass(EventCodes::class);
 
-        foreach ($class_vars as $property => $value) {
+        foreach (self::REQUIRED_DATA as $property) {
             if (!isset($data[$property])) {
                 $missing[] = $property;
             }

--- a/src/PaymentStates.php
+++ b/src/PaymentStates.php
@@ -30,4 +30,5 @@ final class PaymentStates
     public const STATE_FAILED = 'failed';
     public const STATE_REFUNDED = 'refunded';
     public const STATE_PARTIALLY_REFUNDED = 'partially_refunded';
+    public const STATE_REFUND_CARD_SCHEME_FAILED = 'refund_card_scheme_failed';
 }

--- a/src/PaymentStates.php
+++ b/src/PaymentStates.php
@@ -30,5 +30,5 @@ final class PaymentStates
     public const STATE_FAILED = 'failed';
     public const STATE_REFUNDED = 'refunded';
     public const STATE_PARTIALLY_REFUNDED = 'partially_refunded';
-    public const STATE_REFUND_CARD_SCHEME_FAILED = 'refund_card_scheme_failed';
+    public const STATE_REFUND_FAILED = 'refund_failed';
 }

--- a/src/Processor/ProcessorFactory.php
+++ b/src/Processor/ProcessorFactory.php
@@ -34,6 +34,7 @@ class ProcessorFactory
         EventCodes::AUTHORISATION => AuthorisationProcessor::class,
         EventCodes::OFFER_CLOSED => OfferClosedProcessor::class,
         EventCodes::REFUND => RefundProcessor::class,
+        EventCodes::REFUND_FAILED => RefundFailedProcessor::class
     ];
 
     /**

--- a/src/Processor/RefundFailedProcessor.php
+++ b/src/Processor/RefundFailedProcessor.php
@@ -37,7 +37,7 @@ class RefundFailedProcessor extends Processor implements ProcessorInterface
         ];
 
         if ($this->notification->isSuccess() && $state === PaymentStates::STATE_REFUNDED) {
-            $state = PaymentStates::STATE_REFUND_CARD_SCHEME_FAILED;
+            $state = PaymentStates::STATE_REFUND_FAILED;
         }
 
         $logContext['newState'] = $state;

--- a/src/Processor/RefundFailedProcessor.php
+++ b/src/Processor/RefundFailedProcessor.php
@@ -36,7 +36,7 @@ class RefundFailedProcessor extends Processor implements ProcessorInterface
             'originalState' => $state
         ];
 
-        if ($state === PaymentStates::STATE_REFUNDED) {
+        if ($this->notification->isSuccess() && $state === PaymentStates::STATE_REFUNDED) {
             $state = PaymentStates::STATE_REFUND_CARD_SCHEME_FAILED;
         }
 

--- a/src/Processor/RefundFailedProcessor.php
+++ b/src/Processor/RefundFailedProcessor.php
@@ -30,12 +30,16 @@ class RefundFailedProcessor extends Processor implements ProcessorInterface
 {
     public function process(): ?string
     {
+        $state = $this->initialState;
         $logContext = [
             'eventCode' => EventCodes::REFUND_FAILED,
-            'originalState' => $this->initialState
+            'originalState' => $state
         ];
 
-        $state = PaymentStates::STATE_REFUND_CARD_SCHEME_FAILED;
+        if ($state === PaymentStates::STATE_REFUNDED) {
+            $state = PaymentStates::STATE_REFUND_CARD_SCHEME_FAILED;
+        }
+
         $logContext['newState'] = $state;
 
         $this->log('info', 'Processed ' . EventCodes::REFUND_FAILED . ' notification.', $logContext);

--- a/src/Processor/RefundFailedProcessor.php
+++ b/src/Processor/RefundFailedProcessor.php
@@ -21,12 +21,25 @@
  *
  */
 
-namespace Adyen\Webhook;
+namespace Adyen\Webhook\Processor;
 
-final class EventCodes
+use Adyen\Webhook\EventCodes;
+use Adyen\Webhook\PaymentStates;
+
+class RefundFailedProcessor extends Processor implements ProcessorInterface
 {
-    public const AUTHORISATION = 'AUTHORISATION';
-    public const OFFER_CLOSED = 'OFFER_CLOSED';
-    public const REFUND = 'REFUND';
-    public const REFUND_FAILED = 'REFUND_FAILED';
+    public function process(): ?string
+    {
+        $logContext = [
+            'eventCode' => EventCodes::REFUND_FAILED,
+            'originalState' => $this->initialState
+        ];
+
+        $state = PaymentStates::STATE_REFUND_CARD_SCHEME_FAILED;
+        $logContext['newState'] = $state;
+
+        $this->log('info', 'Processed ' . EventCodes::REFUND_FAILED . ' notification.', $logContext);
+
+        return $state;
+    }
 }

--- a/tests/Unit/Processor/ProcessorFactoryTest.php
+++ b/tests/Unit/Processor/ProcessorFactoryTest.php
@@ -92,6 +92,7 @@ class ProcessorFactoryTest extends TestCase
     {
         $notification = $this->createNotificationSuccess([
             'eventCode' => 'REFUND_FAILED',
+            'success' => 'true',
         ]);
         $processor = ProcessorFactory::create($notification, 'refunded');
 
@@ -103,7 +104,7 @@ class ProcessorFactoryTest extends TestCase
         return [
             [
                 [],
-                ['error' => true, 'errorMessage' => 'Field(s) missing from notification data: eventCode'],
+                ['error' => true, 'errorMessage' => 'Field(s) missing from notification data: eventCode, success'],
             ],
             [
                 ['eventCode' => 'foobar', 'success' => true],

--- a/tests/Unit/Processor/ProcessorFactoryTest.php
+++ b/tests/Unit/Processor/ProcessorFactoryTest.php
@@ -28,6 +28,7 @@ use Adyen\Webhook\Notification;
 use Adyen\Webhook\Processor\AuthorisationProcessor;
 use Adyen\Webhook\Processor\OfferClosedProcessor;
 use Adyen\Webhook\Processor\ProcessorFactory;
+use Adyen\Webhook\Processor\RefundFailedProcessor;
 use Adyen\Webhook\Processor\RefundProcessor;
 use PHPUnit\Framework\TestCase;
 
@@ -87,12 +88,22 @@ class ProcessorFactoryTest extends TestCase
         $this->assertInstanceOf(RefundProcessor::class, $processor);
     }
 
+    public function testCreateRefundFailedProcessor()
+    {
+        $notification = $this->createNotificationSuccess([
+            'eventCode' => 'REFUND_FAILED',
+        ]);
+        $processor = ProcessorFactory::create($notification, 'refunded');
+
+        $this->assertInstanceOf(RefundFailedProcessor::class, $processor);
+    }
+
     public static function invalidNotificationData(): array
     {
         return [
             [
                 [],
-                ['error' => true, 'errorMessage' => 'Field(s) missing from notification data: eventCode, success'],
+                ['error' => true, 'errorMessage' => 'Field(s) missing from notification data: eventCode'],
             ],
             [
                 ['eventCode' => 'foobar', 'success' => true],


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

Support for the [REFUND_FAILED](https://docs.adyen.com/online-payments/refund#refund-failed) notification will be added.

Its processor should check if the state of the payment passed by the plugin is **REFUNDED**. If it is, return the **REFUND_FAILED** state. Otherwise (we have a REFUND_FAILED but the original payment has not been set to refunded), return the original state passed by the plugin.

Also update the validation in the `Notification.php` class since this notification will not contain the `success` field.

**Steps:**
1. Handle REFUND_FAILED notification by creating a new processor.
2. Update `Notification` validation.
3. Create refund for the new processor.

## Tested scenarios
Unit tests

