### PR TITLE
pspReference Null coalescing and String check 

### DIFF
--- a/src/Receiver/NotificationReceiver.php
+++ b/src/Receiver/NotificationReceiver.php
@@ -138,7 +138,7 @@ class NotificationReceiver
      */
     public function isTestNotification($pspReference)
     {
-        if(!is_string($pspReference)){
+        if (!is_string($pspReference)) {
             return false;
         }
 

--- a/src/Receiver/NotificationReceiver.php
+++ b/src/Receiver/NotificationReceiver.php
@@ -56,7 +56,7 @@ class NotificationReceiver
      */
     public function validateHmac($response, $hmacKey)
     {
-        $isTestNotification = $this->isTestNotification($response['pspReference']);
+        $isTestNotification = $this->isTestNotification($response['pspReference'] ?? '');
         if (!$this->hmacSignature->isValidNotificationHMAC($hmacKey, $response)) {
             if ($isTestNotification) {
                 $message = 'HMAC key validation failed';
@@ -138,6 +138,10 @@ class NotificationReceiver
      */
     public function isTestNotification($pspReference)
     {
+        if(!is_string($pspReference)){
+            return false;
+        }
+
         if (strpos(strtolower($pspReference), 'test_') !== false
             || strpos(strtolower($pspReference), 'testnotification_') !== false
         ) {


### PR DESCRIPTION
Added Null coalescing to "pspReference" response parameter. Added string check to isTestNotification()

## Summary
The NotificationReceiver method validateHmac() crashes when the property 'pspReference' is missing on the $response array.
Somehow, this property was not always set for all my notifications. 

The method isTestNotification() uses string comparison on this property to determine whether the notification is indeed a test. 
But the function strtolower() does not accept null. 
So if somehow the "pspReference" is missing from the response, this workflow generates a PHP error and crashes the process, which should otherwise be a valid notification.

## Tested scenarios
Created a Standard notification Webhook in the Adyen Customer Area.
Configured my endpoint for JSON, HTTP Authentication and HMAC signature.
Then generated an AUTHORIZATION test notification, using the "Test configuration" button.
