### PR TITLE
Notification method isSuccess() always returns true

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -59,7 +59,7 @@ class Notification
 
     public function isSuccess(): bool
     {
-        return in_array($this->success, [true, "true"]);
+        return in_array($this->success, [true, "true"], true);
     }
 
     private static function validateNotificationData(array $data)


### PR DESCRIPTION
Property "success" is evaluating wrongly.

## Summary
When using JSON for Notifications, the decoded value for property $response["success"] may be a String.
Example for a failed response, { success: "false" }

The method Notification->isSuccess() compares that value with an array of [ true, "true" ] and this fails, because the string "false" is evaluating as true.

# Suggestion:
in_array() should be using strict-type checking when comparing an unknown value with a real Boolean, because any String or any Number different than zero will otherwise evaluate as true.

## Tested scenarios
Created a Standard notification Webhook in the Adyen Customer Area.
Configured my endpoint for JSON, HTTP Authentication and HMAC signature.
Then generated an AUTHORIZATION test notification, using the "Test configuration" button.