### PR TITLE
[PW-5251] Update notification validation message

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -83,7 +83,7 @@ class Notification
             // If an invalid event code is passed
             if (isset($data[self::PROPERTY_EVENT_CODE]) &&
                 !in_array($data[self::PROPERTY_EVENT_CODE], $eventCodes->getConstants())) {
-                $invalid[] = self::PROPERTY_EVENT_CODE;
+                $invalid[self::PROPERTY_EVENT_CODE] = $data[self::PROPERTY_EVENT_CODE];
             }
         }
 

--- a/tests/Unit/Processor/ProcessorFactoryTest.php
+++ b/tests/Unit/Processor/ProcessorFactoryTest.php
@@ -103,7 +103,7 @@ class ProcessorFactoryTest extends TestCase
             ],
             [
                 ['eventCode' => 'foobar', 'success' => true],
-                ['error' => true, 'errorMessage' => 'Invalid value for the field(s) with key(s): eventCode']
+                ['error' => true, 'errorMessage' => 'Invalid value for the field(s) with key(s): foobar']
             ]
         ];
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
We updated the error message to contain both the key where the invalid value is and the actual value. This is done by adding  associative array if an invalid event code is passed


## Tested scenarios
<!-- Description of tested scenarios -->
- Tests are passing

**Fixed issue**:  <!-- #-prefixed issue number -->
