### PR TITLE
[ECP-8368] Implement isAutoCapture flag to ProcessorFactory

### DIFF
--- a/src/PaymentStates.php
+++ b/src/PaymentStates.php
@@ -28,6 +28,7 @@ final class PaymentStates
     public const STATE_IN_PROGRESS = 'in_progress';
     public const STATE_PENDING = 'pending';
     public const STATE_PAID = 'paid';
+    public const STATE_AUTHORIZED = 'authorized';
     public const STATE_FAILED = 'failed';
     public const STATE_REFUNDED = 'refunded';
     public const STATE_PARTIALLY_REFUNDED = 'partially_refunded';

--- a/src/Processor/AuthorisationProcessor.php
+++ b/src/Processor/AuthorisationProcessor.php
@@ -35,7 +35,11 @@ class AuthorisationProcessor extends Processor implements ProcessorInterface
             $state,
             [PaymentStates::STATE_NEW, PaymentStates::STATE_IN_PROGRESS, PaymentStates::STATE_PENDING]
         )) {
-            $state = $this->notification->isSuccess() ? PaymentStates::STATE_PAID : PaymentStates::STATE_FAILED;
+            if ($this->notification->isSuccess()) {
+                $state = $this->isAutoCapture ? PaymentStates::STATE_PAID : PaymentStates::STATE_AUTHORIZED;
+            } else {
+                $state = PaymentStates::STATE_FAILED;
+            }
         }
 
         return $state;

--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -39,16 +39,26 @@ abstract class Processor implements ProcessorInterface
      */
     protected $initialState;
 
+    /**
+     * @var bool
+     */
+    protected $isAutoCapture;
+
     abstract public function process(): ?string;
 
     /**
      * @param Notification $notification
      * @param string $state
+     * @param bool $isAutoCapture
      * @throws InvalidDataException
      */
-    public function __construct(Notification $notification, string $state)
-    {
+    public function __construct(
+        Notification $notification,
+        string $state,
+        bool $isAutoCapture = true
+    ) {
         $this->notification = $notification;
+        $this->isAutoCapture = $isAutoCapture;
         $this->validateState($state);
 
         $this->initialState = $state;

--- a/src/Processor/ProcessorFactory.php
+++ b/src/Processor/ProcessorFactory.php
@@ -24,11 +24,12 @@
 namespace Adyen\Webhook\Processor;
 
 use Adyen\Webhook\EventCodes;
+use Adyen\Webhook\Exception\InvalidDataException;
 use Adyen\Webhook\Notification;
 
 class ProcessorFactory
 {
-    private static $adyenEventCodeProcessors = [
+    private static array $adyenEventCodeProcessors = [
         EventCodes::AUTHORISATION => AuthorisationProcessor::class,
         EventCodes::OFFER_CLOSED => OfferClosedProcessor::class,
         EventCodes::REFUND => RefundProcessor::class,
@@ -57,14 +58,21 @@ class ProcessorFactory
     /**
      * @param Notification $notification
      * @param string $paymentState
+     * @param bool $isAutoCapture
      * @return ProcessorInterface
+     * @throws InvalidDataException
      */
     public static function create(
         Notification    $notification,
-        string          $paymentState
+        string          $paymentState,
+        bool            $isAutoCapture = true
     ): ProcessorInterface {
         return array_key_exists($notification->getEventCode(), self::$adyenEventCodeProcessors)
-            ? new self::$adyenEventCodeProcessors[$notification->getEventCode()]($notification, $paymentState)
-            : new DefaultProcessor($notification, $paymentState);
+            ? new self::$adyenEventCodeProcessors[$notification->getEventCode()](
+                $notification,
+                $paymentState,
+                $isAutoCapture
+            )
+            : new DefaultProcessor($notification, $paymentState, $isAutoCapture);
     }
 }

--- a/tests/Unit/Processor/ProcessorFactoryTest.php
+++ b/tests/Unit/Processor/ProcessorFactoryTest.php
@@ -141,6 +141,8 @@ class ProcessorFactoryTest extends TestCase
     {
         return [
             [EventCodes::AUTHORISATION, PaymentStates::STATE_NEW, PaymentStates::STATE_PAID, 'true'],
+            [EventCodes::AUTHORISATION, PaymentStates::STATE_NEW, PaymentStates::STATE_FAILED, 'false'],
+            [EventCodes::AUTHORISATION, PaymentStates::STATE_NEW, PaymentStates::STATE_AUTHORIZED, 'true', false],
             [EventCodes::AUTHORISATION, PaymentStates::STATE_IN_PROGRESS, PaymentStates::STATE_PAID, 'true'],
             [EventCodes::AUTHORISATION, PaymentStates::STATE_PENDING, PaymentStates::STATE_PAID, 'true'],
             [EventCodes::CANCELLATION, PaymentStates::STATE_NEW, PaymentStates::STATE_CANCELLED, 'true'],
@@ -202,13 +204,18 @@ class ProcessorFactoryTest extends TestCase
     /**
      * @dataProvider processorPaymentStatesProvider
      */
-    public function testProcessorPaymentStates($eventCode, $originalState, $expectedState, $success)
-    {
+    public function testProcessorPaymentStates(
+        $eventCode,
+        $originalState,
+        $expectedState,
+        $success,
+        $isAutoCapture = true
+    ) {
         $notification = $this->createNotificationSuccess([
             'eventCode' => $eventCode,
             'success' => $success,
         ]);
-        $processor = ProcessorFactory::create($notification, $originalState);
+        $processor = ProcessorFactory::create($notification, $originalState, $isAutoCapture);
         $newState = $processor->process();
         $this->assertEquals($expectedState, $newState);
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
`isAutoCapture` flag has been added to `ProcessorFactory` as a new argument to `create()` method.

If this flag is set to `false`, then `AuthorisationProcessor` returns `authorized` as the new state. Otherwise it returns `paid` for successful `AUTHORISATION` webhooks.

## Tested scenarios
<!-- Description of tested scenarios -->
- Manual capture case
